### PR TITLE
livereload.port配置不生效

### DIFF
--- a/lib/deploy.js
+++ b/lib/deploy.js
@@ -4,24 +4,31 @@
  */
 
 'use strict';
-var port = fis.config.get('livereload.port', 8132);
-var hostname = fis.config.get('livereload.hostname', (function(){
-    var net = require('os').networkInterfaces();
-    for(var key in net){
-        if(net.hasOwnProperty(key)){
-            var details = net[key];
-            if(details && details.length){
-                for(var i = 0, len = details.length; i < len; i++){
-                    var ip = String(details[i].address).trim();
-                    if(ip && /^\d+(?:\.\d+){3}$/.test(ip) && ip !== '127.0.0.1'){
-                        return ip;
+
+var _livereloadSrc = '';
+function getLivereloadJs(){
+    if (_livereloadSrc) return _livereloadSrc;
+    var port = fis.config.get('livereload.port', 8132);
+    var hostname = fis.config.get('livereload.hostname', (function(){
+        var net = require('os').networkInterfaces();
+        for(var key in net){
+            if(net.hasOwnProperty(key)){
+                var details = net[key];
+                if(details && details.length){
+                    for(var i = 0, len = details.length; i < len; i++){
+                        var ip = String(details[i].address).trim();
+                        if(ip && /^\d+(?:\.\d+){3}$/.test(ip) && ip !== '127.0.0.1'){
+                            return ip;
+                        }
                     }
                 }
             }
         }
-    }
-    return '127.0.0.1';
-})());
+        return '127.0.0.1';
+    })());
+    _livereloadSrc = 'http://' + hostname + ':' + port + '/livereload.js';
+    return _livereloadSrc;
+}
 
 function upload(receiver, to, release, content, subpath, callback){
     fis.util.upload(
@@ -108,7 +115,7 @@ function deploy(dest, file, callback){
                 content = content.replace(reg, dest.replace.to);
             }
             if(dest.opt.live && file.isHtmlLike){
-                var code = '<script type="text/javascript" charset="utf-8" src="http://' + hostname + ':' + port + '/livereload.js"></script>';
+                var code = '<script type="text/javascript" charset="utf-8" src="'+getLivereloadJs()+'"></script>';
                 content = content.replace(/"(?:[^\\"\r\n\f]|\\[\s\S])*"|'(?:[^\\'\n\r\f]|\\[\s\S])*'|(<\/body>)/ig, function(m, $1){
                     if($1){
                         m = code + m;


### PR DESCRIPTION
配置文件还没有加载就已经读取配置属性，
端口监听部分没有问题，写引用地址的时候读取的还是默认的，
导致livereload.js文件404

``` javascript
fis.config.merge({
    livereload : {
        port : 8133
    }
});
```
