### PR TITLE
project.exclude不再默认加入监听exclude

### DIFF
--- a/release.js
+++ b/release.js
@@ -47,10 +47,6 @@ exports.register = function(commander){
             .watch(root, {
                 ignored : function(path){
                     var ignored = ignoredReg.test(path);
-                    if (fis.config.get('project.exclude')){
-                        ignored = ignored ||
-                            fis.util.filter(path, fis.config.get('project.exclude'));
-                    }
                     if (fis.config.get('project.watch.exclude')){
                         ignored = ignored ||
                             fis.util.filter(path, fis.config.get('project.watch.exclude'));


### PR DESCRIPTION
因为无法等价实现project.include

修复问题https://github.com/fex-team/fis/issues/455

对于其中提到的

> 后续对文件的修改进行监控的时候，chokidar给ignore函数里传入的path参数由首次编译时的相对路径变为了文件系统下的绝对路径, 比如原先是asset/js/a.js变成了/tmp/project/asset/js/a.js,这时候exclude的检测也失效了，因为那些检测条件都是以项目目录为根目录来写的

需要一些回归测试后修改，看看是否是因为chokidar版本更新导致