### PR TITLE
https://github.com/fex-team/fis-kernel/issues/15

### DIFF
--- a/release.js
+++ b/release.js
@@ -22,7 +22,8 @@ exports.register = function(commander){
                     if (type == 'add' || type == 'change') {
                         if (!opt.srcCache[file.subpath]) {
                             var file = fis.file(path);
-                            opt.srcCache[file.subpath] = file;
+                            if (file.release)
+                                opt.srcCache[file.subpath] = file;
                         }
                     } else if (type == 'unlink') {
                         if (opt.srcCache[file.subpath]) {


### PR DESCRIPTION
匹配fis.project.getSource()的逻辑,  如果是不release的文件, 不用加入watch列表中, 否则watch和release的文件会不一致.