### PR TITLE
support base config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fis-command-release",
   "description": "fis release command.",
-  "version": "0.12.2",
+  "version": "0.12.3",
   "author": "FIS Team <fis@baidu.com>",
   "homepage": "http://fis.baidu.com/",
   "keywords": [

--- a/release.js
+++ b/release.js
@@ -230,7 +230,7 @@ exports.register = function(commander){
             if(options.verbose){
                 fis.log.level = fis.log.L_ALL;
             }
-            var root, conf, filename = 'fis-conf.js';
+            var root, conf, filename = 'fis-conf.js', baseConf, baseFilename = "base-fisconf.js";
             if(options.file){
                 if(fis.util.isFile(options.file)){
                     conf = fis.util.realpath(options.file);
@@ -278,6 +278,13 @@ exports.register = function(commander){
                     options.clean = true;
                     cache.save();
                 }
+
+                //base fis config
+                baseConf = fis.util.realpath(root + "/../" + baseFilename);
+                if(fis.util.exists(baseConf) && fis.util.isFile(baseConf)){
+                    require(baseConf);
+                }
+
                 require(conf);
                 fis.emitter.emit('fis-conf:loaded');
             } else {


### PR DESCRIPTION
升级功能：支持项目下各模块的共有fis配置
升级原因：通常一个项目包含了很多模块，而模块间的配置例如domain、deploy、bdtmpl等大都是一样的，在现有模式下如果需要修改配置的话，就需要在各个模块中修改fis-conf.js，比较繁琐
使用说明：可在项目目录下新建一个base-fisconf.js，配置方式同fis-conf.js
其它说明：共有配置的优先级低于模块中的配置（利于覆盖），没有共有配置也不受影响，目前在我们业务线已经使用两个多月了，感觉很方便，所以推荐给fis团队看看