### PR TITLE
保持process.argv不变

### DIFF
--- a/release.js
+++ b/release.js
@@ -270,7 +270,7 @@ exports.register = function(commander){
             //init project
             fis.project.setProjectRoot(root);
 
-            process.title = 'fis ' + process.argv.splice(2).join(' ') + ' [ ' + root + ' ]';
+            process.title = 'fis ' + process.argv.slice(2).join(' ') + ' [ ' + root + ' ]';
 
             if(conf){
                 var cache = fis.cache(conf, 'conf');


### PR DESCRIPTION
process.argv.splice(2) 导致命令行参数被删除，在fis-conf.js中无法读取到当前build的相关信息，
无法适配不同release场景